### PR TITLE
fix: duplicate series when scraping metrics w pod monitor

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -22,6 +22,12 @@ var svGvr = schema.GroupVersionResource{
 	Resource: "servicemonitors",
 }
 
+var pmGvr = schema.GroupVersionResource{
+	Group:    "monitoring.coreos.com",
+	Version:  "v1",
+	Resource: "podmonitors",
+}
+
 var isbGvr = schema.GroupVersionResource{
 	Group:    "numaflow.numaproj.io",
 	Version:  "v1alpha1",
@@ -100,11 +106,11 @@ var setupCmd = &cobra.Command{
 		}
 
 		// Install metrics service monitors
-		if err := util.CreateResource("./config/numaflow/pipeline-metrics.yaml", dynamicClient, svGvr, util.PerfmanNamespace, log); err != nil {
-			return fmt.Errorf("failed to create service monitor for pipeline metrics: %w", err)
+		if err := util.CreateResource("./config/numaflow/pipeline-metrics.yaml", dynamicClient, pmGvr, util.PerfmanNamespace, log); err != nil {
+			return fmt.Errorf("failed to create pod monitor for pipeline metrics: %w", err)
 		}
-		if err := util.CreateResource("./config/numaflow/monovertex-metrics.yaml", dynamicClient, svGvr, util.PerfmanNamespace, log); err != nil {
-			return fmt.Errorf("failed to create service monitor for monovertex metrics: %w", err)
+		if err := util.CreateResource("./config/numaflow/monovertex-metrics.yaml", dynamicClient, pmGvr, util.PerfmanNamespace, log); err != nil {
+			return fmt.Errorf("failed to create pod monitor for monovertex metrics: %w", err)
 		}
 		if err := util.CreateResource("./config/numaflow/isbvc-jetstream-metrics.yaml", dynamicClient, svGvr, util.PerfmanNamespace, log); err != nil {
 			return fmt.Errorf("failed to create service monitor for jetstream metrics: %w", err)

--- a/config/numaflow/monovertex-metrics.yaml
+++ b/config/numaflow/monovertex-metrics.yaml
@@ -9,12 +9,19 @@ metadata:
   name: perfman-numaflow-monovertex-metrics
 spec:
   podMetricsEndpoints:
+    # MonoVertex pods run several containers (udsource, transformer, udf, udsink, …), each possibly
+    # exposing port "metrics" → duplicate series per pod. Keep only CtrMain ("numa") targets.
+    # Use relabelings (not spec.container) for older prometheus-operator CRDs that reject `container`.
     - path: /metrics
       port: metrics
       interval: 15s
       scheme: https
       tlsConfig:
         insecureSkipVerify: true
+      relabelings:
+        - action: keep
+          sourceLabels: [__meta_kubernetes_pod_container_name]
+          regex: numa
   selector:
     matchLabels:
       app.kubernetes.io/component: mono-vertex


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->
**Issues**
-  setup pointed at the ServiceMonitor API for PodMonitor manifests
- grafana dashboard showed duplicate lines displaying the same pod metrics
### Modifications
- Fix setup so pipeline and MonoVertex manifests are applied as PodMonitors (not ServiceMonitors)
- filter MonoVertex PodMonitor targets to the numa container via relabelings so that multiple metrics endpoints in the same pod are not scraped


<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification
Tested by looking at monovertex metrics on grafana dashboard with new changes, no more duplicate lines
<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->
